### PR TITLE
Fix issue w/ cross node pod communication

### DIFF
--- a/scripts/common.bash
+++ b/scripts/common.bash
@@ -57,3 +57,7 @@ sudo apt-mark hold kubelet kubeadm kubectl
 
 vagrant_home="/home/vagrant"
 echo "alias k='kubectl'" >> /home/vagrant/.bash_aliases
+
+# Enable the br_netfilter module for cluster networking
+echo "br_netfilter" | sudo tee /etc/modules-load.d/br_netfilter.conf
+sudo systemctl restart systemd-modules-load.service

--- a/scripts/setup-controlplane.bash
+++ b/scripts/setup-controlplane.bash
@@ -27,8 +27,15 @@ chmod +x $shared_kube_config_path/workernode_join.sh
 
 kubeadm token create --print-join-command > $shared_kube_config_path/workernode_join.sh
 
-# Install Flannel CNI
-kubectl apply -f https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml
+# Install Flannel CNI w/ custom iface for Vagrant
+curl -o /vagrant/configs/kube-flannel.yml \
+  https://raw.githubusercontent.com/flannel-io/flannel/refs/tags/v0.26.2/Documentation/kube-flannel.yml
+perl \
+  -i.bak \
+  -0777 \
+  -pe 's/(\s*-\s*\/opt\/bin\/flanneld\s*\n\s*args:\s*)/$1- --iface=enp0s8\n        /' \
+  /vagrant/configs/kube-flannel.yml 
+kubectl apply -f /vagrant/configs/kube-flannel.yml
 
 # Set up kubectl config for the vagrant user
 vagrant_home="/home/vagrant"

--- a/scripts/setup-etc-hosts.bash
+++ b/scripts/setup-etc-hosts.bash
@@ -2,6 +2,6 @@
 
 sudo apt-get update -y
 sudo echo "$IP_PREFIX$((IP_LAST_TERM_START)) controlplane" >> /etc/hosts
-for i in `seq 1 ${NUM_WORKER_NODES}`; do
+for i in `seq 1 ${WORKER_NODE_COUNT}`; do
   sudo echo "$IP_PREFIX$((IP_LAST_TERM_START+i)) node0${i}" >> /etc/hosts
 done

--- a/vagrant-settings.yaml
+++ b/vagrant-settings.yaml
@@ -3,10 +3,10 @@ boxes:
   vm_box_version: 20241002.0.0
   controlplane:
     cpus: 2
-    memory: 4096
+    memory: 2048
   workernodes:
     cpus: 1
-    memory: 2048
+    memory: 1024
 network:
   ip_start: 10.0.0.10
   pod_cidr: 10.244.0.0/16


### PR DESCRIPTION
This PR does the following:
- disables swap on the controlplane and worker nodes as required by k8s
- enable the overlay linux module
- enable and configure br_netfilter linux module
- customize kube-flannel install to use specific network interface for Vagrant
- fix misuse of the `WORKER_NODE_COUNT` env var when setting up `/etc/hosts`
- half the memory use of both the controlplane and worker nodes